### PR TITLE
release version 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,12 @@ on:
 
 env:
   CI: true
-  node-version: 20
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-node@v3
-      with:
-        node-version: ${{ env.node-version }}
     - uses: actions/checkout@v3
     - run: npm install
     - run: npm run lint
@@ -22,8 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-node@v3
-      with:
-        node-version: ${{ env.node-version }}
     - uses: actions/checkout@v3
     - run: npm install
     - name: run coverage
@@ -55,23 +50,23 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
-    - run: npm test
+    - run: npm run test-ci
 
-  # windows:
-  #   needs: [ lint, get-lts ]
-  #   runs-on: windows-latest
-  #   strategy:
-  #     matrix:
-  #       node-version: ${{ fromJson(needs.get-lts.outputs.active) }}
-  #     fail-fast: false
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - uses: actions/setup-node@v3
-  #     name: Node.js ${{ matrix.node-version }} on windows-latest
-  #     with:
-  #       node-version: ${{ matrix.node-version }}
-  #   - run: npm install
-  #   - run: npm run test
+  windows:
+    needs: [ lint, get-lts ]
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        node-version: ${{ fromJson(needs.get-lts.outputs.active) }}
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      name: Node.js ${{ matrix.node-version }} on windows-latest
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm run test-ci
 
   get-lts:
      runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           registry-url: https://registry.npmjs.org/
+          scope: "@msimerson"
+      - name: rename package with @msimerson scope
+        run: node .npm/prepend-scope.cjs @msimerson
       - name: publish to NPM
         run: npm publish --access=public
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+name: publish
+
+on:
+  workflow_call:
+  push:
+    branches:
+      - master
+    paths:
+      - package.json
+
+env:
+  CI: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v3
+      - run: npm install
+      - run: npm test
+
+  publish-npm:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: true
+      - uses: actions/setup-node@v3
+        with:
+          registry-url: https://registry.npmjs.org/
+      - name: publish to NPM
+        run: npm publish --access=public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
+  publish-gpr:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    environment: ghpm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/setup-node@v3
+        with:
+          registry-url: https://npm.pkg.github.com/
+          scope: "@msimerson"
+      - name: rename package with @msimerson scope
+        run: node .npm/prepend-scope.cjs @msimerson
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npm/prepend-scope.js
+++ b/.npm/prepend-scope.js
@@ -1,0 +1,16 @@
+#!node
+function usage () {
+    console.log(`${process.argv[1]} <scope>`)
+    process.exit(1)
+}
+const scope = process.argv[2]; if (!scope) usage()
+const fs = require('fs')
+const pkg = JSON.parse(fs.readFileSync('./package.json'))
+const checkExistsRe = new RegExp(`^${scope}/`, 'g')
+// console.log(`name: ${pkg.name}, scope: ${scope}, re: ${checkExistsRe}`)
+if (checkExistsRe.test(pkg.name)) {
+    console.error(`already scoped to ${scope}`)
+    process.exit(1)
+}
+pkg.name = `${scope}/${pkg.name}`
+fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2))

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,15 @@
 All notable changes to the "stun" package will be documented in this file.
 
 
+### [4.0.0] - 2023-12-13
+
+- BREAKING: drop support for node.js <= 16
+    - still works, but no legacy version testing
+- dep(eslint): bump to 8.55.0
+- dep(jest): bump to 29.7.0
+- dep(prettier): bump to 3.1.1
+
+
 ## [2.1.16] - 2023-12-09
 
 - dep(meow): replace with minimist

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 All notable changes to the "stun" package will be documented in this file.
 
 
-### [4.0.0] - 2023-12-13
+### [3.0.0] - 2023-12-13
 
 - BREAKING: drop support for node.js <= 16
     - still works, but no legacy version testing

--- a/package-lock.json
+++ b/package-lock.json
@@ -184,15 +184,6 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
     },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/generator": {
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
@@ -222,15 +213,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -5724,9 +5706,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,21 @@
 {
   "name": "stun",
-  "version": "2.1.15",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stun",
-      "version": "2.1.15",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "binary-data": "^0.6.0",
         "buffer-xor": "^2.0.2",
         "debug": "^4.3.4",
-        "ip": "^1.1.8",
+        "ip": "^2.0.0",
         "ip2buf": "^2.0.0",
         "is-stun": "^2.0.0",
         "minimist": "^1.2.8",
-        "parse-url": "^8.1.0",
         "turbo-crc32": "^1.0.1",
         "universalify": "^2.0.1"
       },
@@ -25,13 +24,13 @@
       },
       "devDependencies": {
         "@nodertc/eslint-config": "^0.3.0",
-        "eslint": "^8.54.0",
-        "eslint-plugin-prettier": "^5.0.0",
+        "eslint": "^8.55.0",
+        "eslint-plugin-prettier": "^5.0.1",
         "jest": "^29.7.0",
-        "prettier": "^3.1.0"
+        "prettier": "^3.1.1"
       },
       "engines": {
-        "node": ">=8.3"
+        "node": ">=18.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -736,9 +735,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.3.tgz",
-      "integrity": "sha512-yZzuIG+jnVu6hNSzFEN07e8BxF3uAzYtQb6uDkaYZLo6oYZDCq454c5kB8zxnzfCYyP4MIuyBn10L0DqwujTmA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -759,9 +758,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.54.0.tgz",
-      "integrity": "sha512-ut5V+D+fOoWPgGGNj83GGjnntO39xDy6DWxO0wb7Jp3DcMX0TfIqdzHF85VTQkerdyGmuuMD9AKAo5KiNlf/AQ==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.55.0.tgz",
+      "integrity": "sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2530,15 +2529,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.54.0.tgz",
-      "integrity": "sha512-NY0DfAkM8BIZDVl6PgSa1ttZbx3xHgJzSNJKYcQglem6CppHyMhRIQkBVSSMaSRnLhig3jsDbEzOjwCVt4AmmA==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.55.0.tgz",
+      "integrity": "sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.3",
-        "@eslint/js": "8.54.0",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.55.0",
         "@humanwhocodes/config-array": "^0.11.13",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -2774,9 +2773,9 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
-      "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.1.tgz",
+      "integrity": "sha512-m3u5RnR56asrwV/lDC4GHorlW75DsFfmUcjfCYylTUs85dBRnB7VM6xG8eCMJdeDRnppzmxZVf1GEPJvl1JmNg==",
       "dev": true,
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0",
@@ -3334,9 +3333,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.23.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -3576,9 +3575,9 @@
       }
     },
     "node_modules/ip": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
     "node_modules/ip2buf": {
       "version": "2.0.0",
@@ -5254,22 +5253,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parse-path": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.0.tgz",
-      "integrity": "sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==",
-      "dependencies": {
-        "protocols": "^2.0.0"
-      }
-    },
-    "node_modules/parse-url": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-8.1.0.tgz",
-      "integrity": "sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==",
-      "dependencies": {
-        "parse-path": "^7.0.0"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5404,9 +5387,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -5477,11 +5460,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/protocols": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
-      "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "bin": "./src/cli.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nodertc/stun.git"
+    "url": "git+https://github.com/msimerson/stun.git"
   },
   "keywords": [
     "webrtc",
@@ -26,9 +26,9 @@
   "author": "Dmitry Tsvettsikh <me@reklatsmasters.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/nodertc/stun/issues"
+    "url": "https://github.com/msimerson/stun/issues"
   },
-  "homepage": "https://github.com/nodertc/stun#readme",
+  "homepage": "https://github.com/msimerson/stun#readme",
   "devDependencies": {
     "@nodertc/eslint-config": "^0.3.0",
     "eslint": "^8.54.0",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "stun",
-  "version": "2.1.16",
+  "version": "3.0.0",
   "description": "Session Traversal Utilities for NAT (STUN) client and server.",
   "main": "src/index.js",
   "scripts": {
     "lint": "npx eslint .",
-    "lint-fix": "npx eslint . --fix",
-    "cover": "npx jest --coverage",
+    "lint-fix": "npx eslint --fix .",
     "test": "npm run lint && npx jest",
-    "test-ci": "npm run lint && npm run cover"
+    "test-ci": "npx jest",
+    "versions": "npx dependency-version-checker check"
   },
   "bin": "./src/cli.js",
   "repository": {
@@ -31,16 +31,16 @@
   "homepage": "https://github.com/msimerson/stun#readme",
   "devDependencies": {
     "@nodertc/eslint-config": "^0.3.0",
-    "eslint": "^8.54.0",
-    "eslint-plugin-prettier": "^5.0.0",
+    "eslint": "^8.55.0",
+    "eslint-plugin-prettier": "^5.0.1",
     "jest": "^29.7.0",
-    "prettier": "^3.1.0"
+    "prettier": "^3.1.1"
   },
   "dependencies": {
     "binary-data": "^0.6.0",
     "buffer-xor": "^2.0.2",
     "debug": "^4.3.4",
-    "ip": "^1.1.8",
+    "ip": "^2.0.0",
     "ip2buf": "^2.0.0",
     "is-stun": "^2.0.0",
     "minimist": "^1.2.8",
@@ -48,7 +48,7 @@
     "universalify": "^2.0.1"
   },
   "engines": {
-    "node": ">=10.0"
+    "node": ">=18.0"
   },
   "jest": {
     "modulePaths": [


### PR DESCRIPTION
- BREAKING: drop support for node.js <= 16
    - still works, but no legacy version testing
- dep(eslint): bump to 8.55.0
- dep(jest): bump to 29.7.0
- dep(prettier): bump to 3.1.1